### PR TITLE
bug fix for undefined process.env.PORT

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,11 +6,11 @@ const mongoose = require("mongoose");
 
 const bodyParser = require("body-parser");
 
-const PORT = process.env.PORT || 5000;
-
 var cors = require("cors");
 
 require("dotenv/config");
+
+const PORT = process.env.PORT || 5000;
 
 // Middlewares - A mechanism to run a function when an endpoint is hit
 


### PR DESCRIPTION
move `PORT` declaration after importing `dotenv/config` so the `.env` file can be read