### PR TITLE
Search filter sort

### DIFF
--- a/routes/postings.js
+++ b/routes/postings.js
@@ -41,7 +41,15 @@ router.get("/search/:query", async (req, res) => {
     const postings = await Posting.find(queryParams, {
       score: { $meta: "textScore" },
     }).sort({ date: "desc", score: {$meta: "textScore"} });
-    res.status(200).json(postings);
+    const postingPreviews = postings.map((post) => (
+      { _id: post._id,    
+        date: post.date,
+        title: post.title,
+        location: post.location,
+        images: post.images[0]}
+    ));
+    res.status(200).json(postingPreviews);
+    // res.status(200).json(postings);
   } catch (err) {
     console.log(err);
     res.status(500).json({

--- a/routes/postings.js
+++ b/routes/postings.js
@@ -22,6 +22,27 @@ router.get("/", async (req, res) => {
 });
 
 // GET
+// returns all active postings
+router.get("/active", async (req, res) => {
+  try {
+    const postings = await Posting.find({active:true}).sort({ date: "desc"});
+    const postingPreviews = postings.map((post) => (
+      { _id: post._id,    
+        date: post.date,
+        title: post.title,
+        location: post.location,
+        images: [post.images[0]]}
+    ));
+    res.status(200).json(postingPreviews);
+  } catch (err) {
+    console.log(err);
+    res.status(500).json({
+      message: "Error code 500: Failed to process request",
+    });
+  }
+});
+
+// GET
 // Returns all postings whose fields contain search query
 router.get("/search/:query", async (req, res) => {
   try {
@@ -46,10 +67,9 @@ router.get("/search/:query", async (req, res) => {
         date: post.date,
         title: post.title,
         location: post.location,
-        images: post.images[0]}
+        images: [post.images[0]]}
     ));
     res.status(200).json(postingPreviews);
-    // res.status(200).json(postings);
   } catch (err) {
     console.log(err);
     res.status(500).json({

--- a/routes/postings.js
+++ b/routes/postings.js
@@ -25,7 +25,7 @@ router.get("/", async (req, res) => {
 // Returns all postings whose fields contain search query
 router.get("/search/:query", async (req, res) => {
   try {
-    let queryParams = {};
+    let queryParams = {active: true};
     let params = new URLSearchParams(req.params.query);
     params.forEach((value, key) => {
       if (key === "category") {
@@ -40,7 +40,7 @@ router.get("/search/:query", async (req, res) => {
     });
     const postings = await Posting.find(queryParams, {
       score: { $meta: "textScore" },
-    }).sort({ score: { $meta: "textScore" } });
+    }).sort({ date: "desc", score: {$meta: "textScore"} });
     res.status(200).json(postings);
   } catch (err) {
     console.log(err);

--- a/routes/users.js
+++ b/routes/users.js
@@ -229,7 +229,7 @@ router.get("/:userId/postings/complete", async (req, res) => {
         date: post.date,
         title: post.title,
         location: post.location,
-        images: post.images[0],
+        images: [post.images[0]],
       offerings: post.offerings}
     ));
     res.status(200).json(postingPreviews);
@@ -314,7 +314,7 @@ router.get("/:userId/postings/active", async (req, res) => {
         date: post.date,
         title: post.title,
         location: post.location,
-        images: post.images[0]}
+        images: [post.images[0]]}
     ));
     res.status(200).json(postingPreviews);
 
@@ -337,7 +337,7 @@ router.get("/:userId/postings/inactive", async (req, res) => {
         date: post.date,
         title: post.title,
         location: post.location,
-        images: post.images[0]}
+        images: [post.images[0]]}
     ));
     res.status(200).json(postingPreviews);
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -224,8 +224,17 @@ router.get("/:userId/postings/complete", async (req, res) => {
       ownerId: req.params.userId,
       active: true,
     }).populate("offerings");
+    const postingPreviews = postingsOfUser.map((post) => (
+      { _id: post._id,    
+        date: post.date,
+        title: post.title,
+        location: post.location,
+        images: post.images[0],
+      offerings: post.offerings}
+    ));
+    res.status(200).json(postingPreviews);
 
-    res.status(200).json(postingsOfUser);
+    // res.status(200).json(postingsOfUser);
   } catch (err) {
     res.status(500).json({
       message: "Error code 500: Failed to process request",
@@ -299,9 +308,17 @@ router.get("/:userId/postings/active", async (req, res) => {
     const postingsOfUser = await Posting.find({
       ownerId: req.params.userId,
       active: true,
-    });
+    });    
+    const postingPreviews = postingsOfUser.map((post) => (
+      { _id: post._id,    
+        date: post.date,
+        title: post.title,
+        location: post.location,
+        images: post.images[0]}
+    ));
+    res.status(200).json(postingPreviews);
 
-    res.status(200).json(postingsOfUser);
+    // res.status(200).json(postingsOfUser);
   } catch (err) {
     res.status(500).json({
       message: "Error code 500: Failed to process request",
@@ -315,8 +332,16 @@ router.get("/:userId/postings/inactive", async (req, res) => {
       ownerId: req.params.userId,
       active: false,
     });
+    const postingPreviews = postingsOfUser.map((post) => (
+      { _id: post._id,    
+        date: post.date,
+        title: post.title,
+        location: post.location,
+        images: post.images[0]}
+    ));
+    res.status(200).json(postingPreviews);
 
-    res.status(200).json(postingsOfUser);
+    // res.status(200).json(postingsOfUser);
   } catch (err) {
     res.status(500).json({
       message: "Error code 500: Failed to process request",


### PR DESCRIPTION
Posting previews in search results and profile page only require a subset of fields from the posting object. Tried to pare down the amount of data sent when getting arrays of postings for previews in an attempt to reduce load time (primarily selecting only the first image as the preview image and not returning the rest).

Additionally, for search endpoint put a default sort by newest date and selected only active postings. 